### PR TITLE
Bekreft

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,18 +19,15 @@ jobs:
         uses: actions/checkout@master
       - name: Gradle wrapper validation
         uses: gradle/wrapper-validation-action@v1
-      - uses: actions/cache@v1
+      - name: Setup gradle dependency cache
+        uses: actions/cache@v2
         with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-cache-${{ hashFiles('build.gradle.kts') }}
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/.*gradle*') }}
           restore-keys: |
-            ${{ runner.os }}-gradle-cache-
-      - uses: actions/cache@v1
-        with:
-          path: ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-wrapper-
+            ${{ runner.os }}-gradle-
       - name: Run tests
         env:
           ORG_GRADLE_PROJECT_githubUser: x-access-token

--- a/.github/workflows/devdeploy.yml
+++ b/.github/workflows/devdeploy.yml
@@ -20,18 +20,15 @@ jobs:
         uses: actions/checkout@master
       - name: Gradle wrapper validation
         uses: gradle/wrapper-validation-action@v1
-      - uses: actions/cache@v1
+      - name: Setup gradle dependency cache
+        uses: actions/cache@v2
         with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-cache-${{ hashFiles('build.gradle.kts') }}
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/.*gradle*') }}
           restore-keys: |
-            ${{ runner.os }}-gradle-cache-
-      - uses: actions/cache@v1
-        with:
-          path: ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-wrapper-
+            ${{ runner.os }}-gradle-
       - name: Run tests
         env:
           ORG_GRADLE_PROJECT_githubUser: x-access-token

--- a/src/main/kotlin/no/nav/syfo/sykmeldingstatus/api/SykmeldingBekreftApi.kt
+++ b/src/main/kotlin/no/nav/syfo/sykmeldingstatus/api/SykmeldingBekreftApi.kt
@@ -4,26 +4,28 @@ import io.ktor.application.call
 import io.ktor.auth.authentication
 import io.ktor.auth.jwt.JWTPrincipal
 import io.ktor.http.HttpStatusCode
+import io.ktor.request.receive
 import io.ktor.response.respond
 import io.ktor.routing.Route
 import io.ktor.routing.post
-import java.time.OffsetDateTime
-import java.time.ZoneOffset
 import no.nav.syfo.metrics.BEKREFTET_AV_BRUKER_COUNTER
 import no.nav.syfo.sykmeldingstatus.SykmeldingStatusService
 
 fun Route.registerSykmeldingBekreftApi(sykmeldingStatusService: SykmeldingStatusService) {
-    post("/api/v1/sykmeldinger/{sykmeldingsid}/bekreft") {
-        val sykmeldingsid = call.parameters["sykmeldingsid"]!!
+    post("/api/v1/sykmeldinger/{sykmeldingid}/bekreft") {
+        val sykmeldingId = call.parameters["sykmeldingid"]!!
         val token = call.request.headers["Authorization"]!!
         val principal: JWTPrincipal = call.authentication.principal()!!
         val fnr = principal.payload.subject
+        val sykmeldingBekreftEventDTO = call.receive<SykmeldingBekreftEventDTO>()
 
-        sykmeldingStatusService.registrerBekreftet(sykmeldingBekreftEventDTO = SykmeldingBekreftEventDTO(OffsetDateTime.now(ZoneOffset.UTC), null),
-                sykmeldingId = sykmeldingsid,
-                source = "user",
-                fnr = fnr,
-                token = token)
+        sykmeldingStatusService.registrerBekreftet(
+            sykmeldingBekreftEventDTO = sykmeldingBekreftEventDTO,
+            sykmeldingId = sykmeldingId,
+            source = "user",
+            fnr = fnr,
+            token = token
+        )
 
         BEKREFTET_AV_BRUKER_COUNTER.inc()
         call.respond(HttpStatusCode.Accepted)

--- a/src/test/kotlin/no/nav/syfo/sykmeldingstatus/api/SykmeldingBekreftSyfoServiceApiSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/sykmeldingstatus/api/SykmeldingBekreftSyfoServiceApiSpek.kt
@@ -13,8 +13,6 @@ import io.ktor.server.testing.setBody
 import io.mockk.coEvery
 import io.mockk.mockkClass
 import java.nio.file.Paths
-import java.time.OffsetDateTime
-import java.time.ZoneOffset
 import no.nav.syfo.Environment
 import no.nav.syfo.VaultSecrets
 import no.nav.syfo.application.setupAuth
@@ -143,12 +141,3 @@ class SykmeldingBekreftSyfoServiceApiSpek : Spek({
         }
     }
 })
-
-fun opprettSykmeldingBekreftEventDTO(): SykmeldingBekreftEventDTO =
-    SykmeldingBekreftEventDTO(
-        OffsetDateTime.now(ZoneOffset.UTC),
-        listOf(SporsmalOgSvarDTO("Sykmeldt fra ", ShortNameDTO.ARBEIDSSITUASJON, SvartypeDTO.ARBEIDSSITUASJON, "Frilanser"),
-            SporsmalOgSvarDTO("Har forsikring?", ShortNameDTO.FORSIKRING, SvartypeDTO.JA_NEI, "Ja"),
-            SporsmalOgSvarDTO("Hatt fravær?", ShortNameDTO.FRAVAER, SvartypeDTO.JA_NEI, "Ja"),
-            SporsmalOgSvarDTO("Når hadde du fravær?", ShortNameDTO.PERIODE, SvartypeDTO.PERIODER, "{[{\"fom\": \"2019-8-1\", \"tom\": \"2019-8-15\"}, {\"fom\": \"2019-9-1\", \"tom\": \"2019-9-3\"}]}"))
-    )

--- a/src/test/kotlin/no/nav/syfo/sykmeldingstatus/api/Testdata.kt
+++ b/src/test/kotlin/no/nav/syfo/sykmeldingstatus/api/Testdata.kt
@@ -1,0 +1,13 @@
+package no.nav.syfo.sykmeldingstatus.api
+
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+
+fun opprettSykmeldingBekreftEventDTO(): SykmeldingBekreftEventDTO =
+    SykmeldingBekreftEventDTO(
+        OffsetDateTime.now(ZoneOffset.UTC),
+        listOf(SporsmalOgSvarDTO("Sykmeldt fra ", ShortNameDTO.ARBEIDSSITUASJON, SvartypeDTO.ARBEIDSSITUASJON, "Frilanser"),
+            SporsmalOgSvarDTO("Har forsikring?", ShortNameDTO.FORSIKRING, SvartypeDTO.JA_NEI, "Ja"),
+            SporsmalOgSvarDTO("Hatt fravær?", ShortNameDTO.FRAVAER, SvartypeDTO.JA_NEI, "Ja"),
+            SporsmalOgSvarDTO("Når hadde du fravær?", ShortNameDTO.PERIODE, SvartypeDTO.PERIODER, "{[{\"fom\": \"2019-8-1\", \"tom\": \"2019-8-15\"}, {\"fom\": \"2019-9-1\", \"tom\": \"2019-9-3\"}]}"))
+    )


### PR DESCRIPTION
Jeg har endret bekreft-apiet som skal være tilgjengelig for sluttbruker slik at det kan brukes for bekrefte både avviste sykmeldinger og andre sykmeldinger som kun skal sendes til NAV (f.eks. frilansere). 

Men, nå når jeg ser resultatet blir jeg litt usikker på om det egentlig er riktig å bruke samme apiet for begge deler, og dermed skrive dem til statusendringstopicen. En bekrefting av en ikke-avvist sykmelding skal jo blant annet trigge oppretting av søknad, mens bekreft av avvist sykmelding kun skal oppdatere registeret. Samtidig er jo også bekrefting av avvist sykmelding en statusendring som bør kunne skrives til statusendringstopicen (som er det vi gjør her). Man kan se forskjell på en bekrefting av en avvist sykmelding og annen bekrefting fordi spørsmål/svar-listen for en avvist sykmelding vil være null, mens for ikke-avviste sykmeldinger vil listen alltid inneholde minst et spørsmål/svar (arbeidssituasjon). Kan vi si at det er konsumentenes ansvar å skille på dette? Syfosoknad lytter vel forresten på egne topics for å få med seg om sykmeldinger er sendt/bekreftet, så da vil det vel i så fall kanskje bare være registeret som må passe på at den ikke skriver bekreft-events uten spørsmål/svar til denne topicen? 