### PR TITLE
Check header for source and set it to syfoservice if it is missing

### DIFF
--- a/src/main/kotlin/no/nav/syfo/sykmeldingstatus/api/SykmeldingSendSyfoServiceApi.kt
+++ b/src/main/kotlin/no/nav/syfo/sykmeldingstatus/api/SykmeldingSendSyfoServiceApi.kt
@@ -16,11 +16,12 @@ fun Route.registerSykmeldingSendSyfoServiceApi(sykmeldingStatusService: Sykmeldi
         val fnr = call.request.headers["FNR"]!!
         val sykmeldingSendEventDTO = call.receive<SykmeldingSendEventDTO>()
         val token = call.request.headers["Authorization"]!!
-
+        val syfoserviceSource = call.request.headers["source"]
+        val source = syfoserviceSource ?: "syfoservice"
         sykmeldingStatusService.registrerSendt(sykmeldingSendEventDTO = sykmeldingSendEventDTO,
                 sykmeldingId =
                 sykmeldingId,
-                source = "syfoservice",
+                source = source,
                 fnr = fnr,
                 token = token)
         log.info("Sendt sykmelding {}", sykmeldingId)


### PR DESCRIPTION
Her må vi la syfoservice bestemme source ved å sjekke header. Om header er user så betyr det at syfoservice ikke har sendt sykmeldingen til altinn og det må da gjøres av syfosmaltinn