### PR TITLE
Arbeidsforhold

### DIFF
--- a/src/main/kotlin/no/nav/syfo/arbeidsgivere/service/ArbeidsgiverService.kt
+++ b/src/main/kotlin/no/nav/syfo/arbeidsgivere/service/ArbeidsgiverService.kt
@@ -49,6 +49,8 @@ class ArbeidsgiverService(
         val arbeidsgiverList = ArrayList<Arbeidsgiverinfo>()
         arbeidsgivere.filter {
             it.arbeidsgiver.type == "Organisasjon"
+        }.sortedByDescending {
+            it.ansettelsesperiode.periode.fom
         }.distinctBy {
             it.arbeidsgiver.organisasjonsnummer
         }.forEach { arbeidsforhold ->

--- a/src/main/kotlin/no/nav/syfo/arbeidsgivere/service/ArbeidsgiverService.kt
+++ b/src/main/kotlin/no/nav/syfo/arbeidsgivere/service/ArbeidsgiverService.kt
@@ -49,8 +49,8 @@ class ArbeidsgiverService(
         val arbeidsgiverList = ArrayList<Arbeidsgiverinfo>()
         arbeidsgivere.filter {
             it.arbeidsgiver.type == "Organisasjon"
-        }.sortedByDescending {
-            it.ansettelsesperiode.periode.fom
+        }.sortedBy {
+            it.ansettelsesperiode.periode.tom != null
         }.distinctBy {
             it.arbeidsgiver.organisasjonsnummer
         }.forEach { arbeidsforhold ->

--- a/src/main/kotlin/no/nav/syfo/sykmeldingstatus/kafka/SykmeldingStatusKafkaMessageMapper.kt
+++ b/src/main/kotlin/no/nav/syfo/sykmeldingstatus/kafka/SykmeldingStatusKafkaMessageMapper.kt
@@ -1,6 +1,7 @@
 package no.nav.syfo.sykmeldingstatus.kafka
 
 import no.nav.syfo.arbeidsgivere.model.Arbeidsgiverinfo
+import no.nav.syfo.log
 import no.nav.syfo.model.sykmeldingstatus.ArbeidsgiverStatusDTO
 import no.nav.syfo.model.sykmeldingstatus.STATUS_APEN
 import no.nav.syfo.model.sykmeldingstatus.STATUS_AVBRUTT
@@ -31,16 +32,16 @@ fun SykmeldingUserEvent.tilSykmeldingStatusKafkaEventDTO(timestamp: OffsetDateTi
                 orgNavn = it.navn,
             )
         },
-        toSporsmalSvarListe(arbeidsgiver),
+        toSporsmalSvarListe(arbeidsgiver, sykmeldingId),
     )
 }
 
-fun SykmeldingUserEvent.toSporsmalSvarListe(arbeidsgiver: Arbeidsgiverinfo? = null): List<SporsmalOgSvarDTO> {
+fun SykmeldingUserEvent.toSporsmalSvarListe(arbeidsgiver: Arbeidsgiverinfo? = null, sykmeldingId: String): List<SporsmalOgSvarDTO> {
     return listOfNotNull(
         arbeidssituasjonSporsmalBuilder(),
         fravarSporsmalBuilder(),
         periodeSporsmalBuilder(),
-        riktigNarmesteLederSporsmalBuilder(arbeidsgiver),
+        riktigNarmesteLederSporsmalBuilder(arbeidsgiver, sykmeldingId),
         forsikringSporsmalBuilder(),
     )
 }
@@ -78,8 +79,9 @@ private fun SykmeldingUserEvent.periodeSporsmalBuilder(): SporsmalOgSvarDTO? {
     return null
 }
 
-private fun SykmeldingUserEvent.riktigNarmesteLederSporsmalBuilder(arbeidsgiver: Arbeidsgiverinfo?): SporsmalOgSvarDTO? {
+private fun SykmeldingUserEvent.riktigNarmesteLederSporsmalBuilder(arbeidsgiver: Arbeidsgiverinfo?, sykmeldingId: String): SporsmalOgSvarDTO? {
     if (arbeidsgiver?.aktivtArbeidsforhold == false) {
+        log.info("Ber ikke om ny nærmeste leder for arbeidsforhold som ikke er aktivt: $sykmeldingId")
         return SporsmalOgSvarDTO(
             tekst = "Skal finne ny nærmeste leder",
             shortName = ShortNameDTO.NY_NARMESTE_LEDER,

--- a/src/test/kotlin/no/nav/syfo/arbeidsgivere/service/ArbeidsgiverServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/arbeidsgivere/service/ArbeidsgiverServiceTest.kt
@@ -247,13 +247,13 @@ class ArbeidsgiverServiceTest : Spek({
             }
             coVerify { arbeidsgiverRedisService.updateArbeidsgivere(any(), any()) }
         }
-        it("arbeidsgiverService velger det nyeste arbeidsforholdet ved duplikate arbeidsforhold for samme orgnummer") {
+        it("arbeidsgiverService velger det aktive arbeidsforholdet ved duplikate arbeidsforhold for samme orgnummer") {
             coEvery { arbeidsforholdClient.getArbeidsforhold(any(), any(), any(), any()) } returns listOf(
                 Arbeidsforhold(
                     Arbeidsgiver("Organisasjon", "123456789"),
                     Opplysningspliktig("Organisasjon", "987654321"),
                     Ansettelsesperiode(
-                        Periode(fom = LocalDate.of(2020, 1, 1), tom = LocalDate.of(2020, 6, 1))
+                        Periode(fom = LocalDate.of(2020, 5, 1), tom = LocalDate.of(2020, 6, 1))
                     ),
                     listOf(
                         Arbeidsavtale(
@@ -269,7 +269,7 @@ class ArbeidsgiverServiceTest : Spek({
                     Arbeidsgiver("Organisasjon", "123456789"),
                     Opplysningspliktig("Organisasjon", "987654321"),
                     Ansettelsesperiode(
-                        Periode(fom = LocalDate.of(2020, 6, 1), tom = null)
+                        Periode(fom = LocalDate.of(2020, 1, 1), tom = null)
                     ),
                     listOf(
                         Arbeidsavtale(

--- a/src/test/kotlin/no/nav/syfo/sykmeldingstatus/api/v2/ValidationKtTest.kt
+++ b/src/test/kotlin/no/nav/syfo/sykmeldingstatus/api/v2/ValidationKtTest.kt
@@ -333,7 +333,7 @@ class ValidationKtTest : Spek({
                 harForsikring = null,
             )
 
-            val sporsmalOgSvarListe = sykmeldingUserEvent.toSporsmalSvarListe()
+            val sporsmalOgSvarListe = sykmeldingUserEvent.toSporsmalSvarListe(sykmeldingId = "id")
 
             val expected = listOf(
                 SporsmalOgSvarDTO(
@@ -385,7 +385,7 @@ class ValidationKtTest : Spek({
                 naermesteLeder = null
             )
 
-            val sporsmalOgSvarListe = sykmeldingUserEvent.toSporsmalSvarListe(arbeidsgiver)
+            val sporsmalOgSvarListe = sykmeldingUserEvent.toSporsmalSvarListe(arbeidsgiver, "id")
 
             val expected = listOf(
                 SporsmalOgSvarDTO(
@@ -443,7 +443,7 @@ class ValidationKtTest : Spek({
                 naermesteLeder = null
             )
 
-            val sporsmalOgSvarListe = sykmeldingUserEvent.toSporsmalSvarListe(arbeidsgiver)
+            val sporsmalOgSvarListe = sykmeldingUserEvent.toSporsmalSvarListe(arbeidsgiver, "id")
 
             val expected = listOf(
                 SporsmalOgSvarDTO(
@@ -491,7 +491,7 @@ class ValidationKtTest : Spek({
                 ),
             )
 
-            val sporsmalOgSvarListe = sykmeldingUserEvent.toSporsmalSvarListe()
+            val sporsmalOgSvarListe = sykmeldingUserEvent.toSporsmalSvarListe(sykmeldingId = "id")
 
             val expected = listOf(
                 SporsmalOgSvarDTO(
@@ -550,7 +550,7 @@ class ValidationKtTest : Spek({
                 harForsikring = null,
             )
 
-            val sporsmalOgSvarListe = sykmeldingUserEvent.toSporsmalSvarListe()
+            val sporsmalOgSvarListe = sykmeldingUserEvent.toSporsmalSvarListe(sykmeldingId = "id")
 
             val expected = listOf(
                 SporsmalOgSvarDTO(


### PR DESCRIPTION
Velger nyeste arbeidsforhold ved duplikater (ikke bare første fra listen), ref denne: https://trello.com/c/Q6GqdfbI/1736-f%C3%A5r-ikke-meldt-inn-nl

Logger dessuten når arbeidsforholdet ikke er aktivt og vi dermed ikke ber om ny NL. Da blir det enklere hvis noen må feilsøke noe relatert til dette en annen gang :)