### PR TITLE
tidligereArbeidsgiver blir ikke lengre lagt inn på index 1 i databasen

### DIFF
--- a/src/main/kotlin/no/nav/syfo/sykmeldingstatus/db/SykmeldingStatusDb.kt
+++ b/src/main/kotlin/no/nav/syfo/sykmeldingstatus/db/SykmeldingStatusDb.kt
@@ -60,7 +60,7 @@ class SykmeldingStatusDb(private val databaseInterface: DatabaseInterface) {
                             ps.setObject(index++, event.arbeidsgiver?.let { toPGObject(it) })
                             ps.setObject(index++, event.sporsmals?.let { toPGObject(it) })
                             ps.setObject(index++, response?.let { toPGObject(it) })
-                            ps.setObject(index, event.tidligereArbeidsgiver?.let { toPGObject(it) })
+                            ps.setObject(index++, event.tidligereArbeidsgiver?.let { toPGObject(it) })
                             ps.executeUpdate()
                         }
                     connection.commit()


### PR DESCRIPTION
en minibug som har gjort at vi aldri noensinne har lagt inn tidligereArbeidsgiver inn. 